### PR TITLE
Propagate inbounds in dnPl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendrePolynomials"
 uuid = "3db4a2ba-fc88-11e8-3e01-49c72059a882"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"


### PR DESCRIPTION
This permits `collectdnPl` to run faster:

On master:
```julia
julia> @btime collectdnPl(0.5, lmax = 80, n = 3);
  4.597 μs (1 allocation: 736 bytes)
```

After this PR:
```julia
julia> @btime collectdnPl(0.5, lmax = 80, n = 3);
  3.800 μs (1 allocation: 736 bytes)
```