### PR TITLE
double factorial: change argument to (::Type{T},n), add inline

### DIFF
--- a/src/LegendrePolynomials.jl
+++ b/src/LegendrePolynomials.jl
@@ -232,7 +232,7 @@ function Pl(x, l::Integer; norm = Val(:standard))
     return maybenormalize(Pl, l, norm)
 end
 
-function doublefactorial(T, n)
+@inline function doublefactorial(::Type{T}, n) where T
     p = convert(T, one(n))
     for i in n:-2:1
         p *= convert(T, i)


### PR DESCRIPTION
This PR fixes issue #23. Currently, all tests passed except the doctests where there are round-off errors. Please let me know if that is an issue.